### PR TITLE
Hacktoberfest checkresponse

### DIFF
--- a/src/Provider/Exception/SlackProviderException.php
+++ b/src/Provider/Exception/SlackProviderException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AdamPaterson\OAuth2\Client\Provider\Exception;
+
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use Psr\Http\Message\ResponseInterface;
+
+class SlackProviderException extends IdentityProviderException
+{
+    /**
+     * @param  ResponseInterface $response
+     * @param  string|null $message
+     * @return IdentityProviderException
+     */
+    public static function fromResponse(ResponseInterface $response, $message = null)
+    {
+        throw new static($message, $response->getStatusCode(), (string) $response->getBody());
+    }
+}

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -6,6 +6,7 @@ use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
+use AdamPaterson\OAuth2\Client\Provider\Exception\SlackProviderException;
 
 /**
  * Class Slack
@@ -79,6 +80,12 @@ class Slack extends AbstractProvider
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
+        error_log(get_class().' :: '.__FUNCTION__);
+        error_log('data: '.var_export($data, true));
+
+        if (isset($data['ok']) && $data['ok'] == false) {
+            return SlackProviderException::fromResponse($response, $data['error']);
+        }
     }
 
     /**

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -80,9 +80,6 @@ class Slack extends AbstractProvider
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
-        error_log(get_class().' :: '.__FUNCTION__);
-        error_log('data: '.var_export($data, true));
-
         if (isset($data['ok']) && $data['ok'] == false) {
             return SlackProviderException::fromResponse($response, $data['error']);
         }


### PR DESCRIPTION
This PR implements the `checkResponse` method in the Provider and adds a new exception type for catching: `SlackProviderException`.