### PR TITLE
[WIP] Use token as Authorization header

### DIFF
--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -51,7 +51,6 @@ class Slack extends AbstractProvider
         $authorizedUser = $this->getAuthorizedUser($token);
 
         $params = [
-            'token' => $token->getToken(),
             'user'  => $authorizedUser->getId()
         ];
 
@@ -144,5 +143,22 @@ class Slack extends AbstractProvider
     protected function createAuthorizedUser($response)
     {
         return new SlackAuthorizedUser($response);
+    }
+
+    /**
+     * Returns the authorization headers used by Slack API.
+     *
+     * @param  mixed|null $token Either a string or an access token instance
+     * @return array
+     */
+    protected function getAuthorizationHeaders($token = null)
+    {
+        $headers = [];
+
+        if ($token) {
+            $headers['Authorization'] = 'Bearer ' . $token->getToken();
+        }
+
+        return $headers;
     }
 }

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -62,9 +62,9 @@ class Slack extends AbstractProvider
      *
      * @return string
      */
-    public function getAuthorizedUserTestUrl($token)
+    public function getAuthorizedUserTestUrl()
     {
-        return 'https://slack.com/api/auth.test?token=' . $token;
+        return 'https://slack.com/api/auth.test';
     }
 
     /**
@@ -111,7 +111,7 @@ class Slack extends AbstractProvider
      */
     public function fetchAuthorizedUserDetails(AccessToken $token)
     {
-        $url = $this->getAuthorizedUserTestUrl($token);
+        $url = $this->getAuthorizedUserTestUrl();
 
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
@@ -153,12 +153,8 @@ class Slack extends AbstractProvider
      */
     protected function getAuthorizationHeaders($token = null)
     {
-        $headers = [];
-
-        if ($token) {
-            $headers['Authorization'] = 'Bearer ' . $token->getToken();
-        }
-
-        return $headers;
+        return [
+            'Authorization'     =>  'Bearer ' . $token->getToken()
+        ];
     }
 }


### PR DESCRIPTION
The main oauth library can automatically add the auth token as Authorization header, instead of adding it as a URL param