### PR TITLE
Add BearerAuthorizationTrait

### DIFF
--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -3,6 +3,7 @@
 namespace AdamPaterson\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
@@ -17,6 +18,8 @@ use AdamPaterson\OAuth2\Client\Provider\Exception\SlackProviderException;
  */
 class Slack extends AbstractProvider
 {
+    use BearerAuthorizationTrait;
+
     /**
      * Returns the base URL for authorizing a client.
      *

--- a/test/src/Provider/SlackTest.php
+++ b/test/src/Provider/SlackTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace AdamPaterson\OAuth2\Client\Test\Provider;
 
+use League\OAuth2\Client\Token\AccessToken;
 use AdamPaterson\OAuth2\Client\Provider\Slack;
 use Mockery as m;
 use ReflectionClass;
@@ -270,5 +271,23 @@ class SlackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($hasFiles, $user->toArray()['user']['has_files']);
 
 
+    }
+
+    public function testGetAuthorizedRequestWithTokenString()
+    {
+        $request = $this->provider->getAuthenticatedRequest('get', 'api.test', 'mock_access_token');
+
+        $this->assertEquals('Bearer mock_access_token', $request->getHeader('Authorization')[0]);
+    }
+
+    public function testGetAuthorizedRequestWithAccessToken()
+    {
+        $accessToken = new AccessToken([
+            'access_token' => 'mock_access_token',
+        ]);
+
+        $request = $this->provider->getAuthenticatedRequest('get', 'api.test', $accessToken);
+
+        $this->assertEquals('Bearer mock_access_token', $request->getHeader('Authorization')[0]);
     }
 }


### PR DESCRIPTION
`BearerAuthorizationTrait` adds the `getAuthorizationHeaders` function which is used in `getAuthenticatedRequest`. 

I was trying to use `getAuthenticatedRequest` like I have with other third party providers to query their APIs and noticed that the token wasn't being inserted. 