### PR TITLE
Use latest Slack v2 OAuth endpoints. Old endpoints are being deprecated. 

### DIFF
--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -24,7 +24,7 @@ class Slack extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return 'https://slack.com/oauth/authorize';
+        return 'https://slack.com/oauth/v2/authorize';
     }
 
     /**
@@ -36,7 +36,7 @@ class Slack extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return 'https://slack.com/api/oauth.access';
+        return 'https://slack.com/api/oauth.v2.access';
     }
 
     /**


### PR DESCRIPTION
New Slack apps must use the new v2 oauth flow. The old endpoints will still work for now, but will be deprecated by the end of 2020. 